### PR TITLE
[1.x] Fixed spelling from `expect` to `except`

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you want to disable monitoring for specific pages you can go to `user-monitor
     /*
      * You can specify pages not to be monitored.
      */
-    'expect_pages' => [
+    'except_pages' => [
         'home',
         'admin/dashboard',
     ],

--- a/config/user-monitoring.php
+++ b/config/user-monitoring.php
@@ -49,7 +49,7 @@ return [
         /*
          * You can specify pages not to be monitored.
          */
-        'expect_pages' => [
+        'except_pages' => [
             // 'home',
         ],
 

--- a/src/Middlewares/VisitMonitoringMiddleware.php
+++ b/src/Middlewares/VisitMonitoringMiddleware.php
@@ -25,9 +25,9 @@ class VisitMonitoringMiddleware
 
         $agent = new Agent();
         $guard = config('user-monitoring.user.guard', 'web');
-        $exceptPages = config('user-monitoring.visit_monitoring.expect_pages', []);
+        $exceptPages = config('user-monitoring.visit_monitoring.except_pages', []);
 
-        if (empty($exceptPages) || !$this->checkIsExpectPages($request->path(), $exceptPages)) {
+        if (empty($exceptPages) || !$this->checkIsExceptPages($request->path(), $exceptPages)) {
             // Store visit
             DB::table(config('user-monitoring.visit_monitoring.table'))->insert([
                 'user_id' => auth($guard)->id(),
@@ -51,7 +51,7 @@ class VisitMonitoringMiddleware
      * @param  array $exceptPages
      * @return bool
      */
-    private function checkIsExpectPages(string $page, array $exceptPages)
+    private function checkIsExceptPages(string $page, array $exceptPages)
     {
         return collect($exceptPages)->contains($page);
     }

--- a/tests/Feature/VisitMonitoringTest.php
+++ b/tests/Feature/VisitMonitoringTest.php
@@ -38,7 +38,7 @@ test('store activity without user when see a page', function () {
 });
 
 test('check except pages are not store', function () {
-    config()->set('user-monitoring.visit_monitoring.expect_pages', ['/']);
+    config()->set('user-monitoring.visit_monitoring.except_pages', ['/']);
 
     $response = get('/');
     $response->assertContent('milwad');


### PR DESCRIPTION
This pull request addresses a minor typo in two files where the word expect was corrected to except. This change improves code readability and ensures consistency.

Changes Made

- [x] In `config/user-monitoring.php`: Replaced occurrences of expect with except.
- [x] In `src/Middlewares/VisitMonitoringMiddleware.php`: Replaced occurrences of expect with except.

Context
The typo fix is straightforward and does not impact the logic or functionality of the code. The change is limited to enhancing the accuracy of the code comments or documentation in these files.