### PR TITLE
[1.x] Update browser and device name detection for missing user agent

### DIFF
--- a/src/Utills/Detector.php
+++ b/src/Utills/Detector.php
@@ -60,6 +60,11 @@ class Detector
             return 'CLI';
         }
 
+        // On some servers, HTTP_USER_AGENT is not available
+        if( !isset($_SERVER['HTTP_USER_AGENT'])) {
+            return 'Unknown Browser';
+        }
+
         $userAgent = $_SERVER['HTTP_USER_AGENT'];
 
         foreach ($this->browserName as $key => $browser) {
@@ -78,6 +83,11 @@ class Detector
     {
         if (PHP_SAPI === 'cli') {
             return 'CLI';
+        }
+
+        // On some servers, HTTP_USER_AGENT is not available
+        if( !isset($_SERVER['HTTP_USER_AGENT'])) {
+            return 'Unknown Device Name';
         }
 
         $userAgent = $_SERVER['HTTP_USER_AGENT'];


### PR DESCRIPTION
Hi, 
in our monitoring, it often happens that the user agent is not set, for example, with webhooks, 404 pages, etc. This PR checks if the $_SERVER variable is set and handles the error accordingly.