### PR TITLE
[1.x] Fix IP address retrieval when using reverse proxy

### DIFF
--- a/config/user-monitoring.php
+++ b/config/user-monitoring.php
@@ -13,7 +13,7 @@ return [
     /*
      * User properties.
      *
-     * You can customize the user guard, table, foreign key, and ... .
+     * You can customize the user guard, table, foreign key, and ...
      */
     'user' => [
         /*
@@ -39,12 +39,12 @@ return [
         /*
          * If you are using uuid or ulid you can change it for the type of foreign_key.
          *
-         * When you are using ulid or uuid, you need to add related traits into the models.
+         * When using ulid or uuid, you need to add related traits into the models.
          */
         'foreign_key_type' => 'id', // uuid, ulid, id
 
         /*
-         * If you want to display custom username, you can create your own attribute in User and change this value.
+         * If you want to display a custom username, you can create your attribute in User and change this value.
          */
         'display_attribute' => 'name',
     ],
@@ -76,7 +76,7 @@ return [
 
         /*
          * If you want to delete visit rows after some days, you can change this to 360 for example,
-         * but you don't like to delete rows you can change it to 0.
+         * but if you don't like to delete rows you can change it to 0.
          *
          * For this feature you need Task-Scheduling => https://laravel.com/docs/10.x/scheduling
          */
@@ -88,6 +88,7 @@ return [
      */
     'action_monitoring' => [
         'table' => 'actions_monitoring',
+
         /*
          * Monitor actions.
          *

--- a/config/user-monitoring.php
+++ b/config/user-monitoring.php
@@ -88,7 +88,6 @@ return [
      */
     'action_monitoring' => [
         'table' => 'actions_monitoring',
-
         /*
          * Monitor actions.
          *
@@ -100,6 +99,14 @@ return [
         'on_read'       => true,
         'on_restore'    => false,
         'on_replicate'  => false,
+        
+        /** 
+        *   Determines if the application should use reverse proxy headers to fetch the real client IP
+        *   If set to true, it will try to get the IP from the specified header (X-Real-IP or X-Forwarded-For)
+        *   This is useful when using reverse proxies like Nginx or Cloudflare.
+         */
+        'use_reverse_proxy_ip' => false,
+        'real_ip_header' => 'X-Forwarded-For'
     ],
 
     /*

--- a/src/Traits/Actionable.php
+++ b/src/Traits/Actionable.php
@@ -73,7 +73,11 @@ trait Actionable
             'browser_name' => $detector->getBrowser(),
             'platform' => $detector->getDevice(),
             'device' => $detector->getDevice(),
-            'ip' => request()->ip(),
+            'ip' => config('user-monitoring.use_reverse_proxy_ip') 
+            ? request()->header(config('user-monitoring.real_ip_header')) 
+                ?: request()->ip() 
+                ?: request()->ip()
+            : request()->ip(),,
             'page' => request()->url(),
             'created_at' => now(),
             'updated_at' => now(),

--- a/src/Traits/Actionable.php
+++ b/src/Traits/Actionable.php
@@ -73,14 +73,20 @@ trait Actionable
             'browser_name' => $detector->getBrowser(),
             'platform' => $detector->getDevice(),
             'device' => $detector->getDevice(),
-            'ip' => config('user-monitoring.use_reverse_proxy_ip') 
-            ? request()->header(config('user-monitoring.real_ip_header')) 
-                ?: request()->ip() 
-                ?: request()->ip()
-            : request()->ip(),,
+            'ip' => $this->getRealIP(),
             'page' => request()->url(),
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    /**
+     * Get real ip.
+     */
+    private function getRealIP(): string
+    {
+        return config('user-monitoring.use_reverse_proxy_ip') 
+                ? request()->header(config('user-monitoring.real_ip_header')) ?: request()->ip() ?: request()->ip()
+                : request()->ip();
     }
 }


### PR DESCRIPTION
This pull request fixes the issue where the request()->ip() method doesn't return the correct IP address when using a reverse proxy (such as Nginx or Cloudflare).
When a reverse proxy is used, the IP address of the proxy is returned instead of the client's real IP. To address this, the code now checks the X-Forwarded-For header to retrieve the correct client IP.